### PR TITLE
Compatibility updates for upstream changes

### DIFF
--- a/js/client.ml
+++ b/js/client.ml
@@ -52,13 +52,13 @@ let start (main:#Dom.node Js.t) =
       return ()
     )
     (fun ex ->
-      let open Tyxml_js.Html5 in
       let msg = Printexc.to_string ex in
       let msg =
         if Regexp.string_match (Regexp.regexp_string "SecurityError:") msg 0 <> None then
           msg ^ " Ensure cookies are enabled (needed to access local storage)."
         else msg in
-      let error = div ~a:[a_class ["alert-box"; "alert"]] [pcdata msg] in
+      let error = Tyxml_js.Html5.(div ~a:[a_class ["alert-box"; "alert"]]
+                                    [pcdata msg]) in
       main##appendChild (Tyxml_js.To_dom.of_node error) |> ignore;
       raise ex
     )

--- a/server/server.ml
+++ b/server/server.ml
@@ -7,7 +7,9 @@ let show_head = function
   | None -> "(none)"
   | Some head -> String.sub (Irmin.Hash.SHA1.to_hum head) 0 6
 
-module Make (Store:Irmin.BASIC) (S:Cohttp_lwt.Server) = struct
+module Make (Store:Irmin.S with type branch_id = string and type commit_id =
+                                                              Irmin.Hash.SHA1.t)
+    (S:Cohttp_lwt.Server) = struct
   module Bundle = Tc.Pair(Store.Private.Slice)(Store.Hash)
 
   let respond_static segments =

--- a/server/server.ml
+++ b/server/server.ml
@@ -8,7 +8,7 @@ let show_head = function
   | Some head -> String.sub (Irmin.Hash.SHA1.to_hum head) 0 6
 
 module Make (Store:Irmin.BASIC) (S:Cohttp_lwt.Server) = struct
-  module Bundle = Tc.Pair(Store.Private.Slice)(Store.Head)
+  module Bundle = Tc.Pair(Store.Private.Slice)(Store.Hash)
 
   let respond_static segments =
     let path = String.concat "/" segments in

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -96,7 +96,9 @@ let n name children = N (name, children)
 
 let assert_str_equal = assert_equal ~printer:(fun x -> x)
 
-module Test_repo (Store : Irmin.BASIC with type key = string list and type value = string)(Test_rpc:Ck_sigs.RPC) = struct
+module Test_repo (Store : Irmin.S with type key = string list
+                                   and type value = string and
+                 type branch_id = string and type commit_id = Irmin.Hash.SHA1.t)(Test_rpc:Ck_sigs.RPC) = struct
   module Git = Git_storage.Make(Store)
   module ItemMap = Map.Make(Key)
   module Slow = Slow_set.Make(Test_clock)(Key)(ItemMap)

--- a/utils/git_storage.ml
+++ b/utils/git_storage.ml
@@ -14,7 +14,8 @@ end
 
 module T = Tar.Make(IO)
 
-module Make (I : Irmin.S with type key = string list and type value = string) = struct
+module Make (I : Irmin.S with type key = string list and type value = string
+             and type commit_id = Irmin.Hash.SHA1.t and type branch_id = string) = struct
   module V = Irmin.View(I)
 
   module Bundle = Tc.Pair(I.Private.Slice)(I.Hash)
@@ -168,7 +169,7 @@ module Make (I : Irmin.S with type key = string list and type value = string) = 
       Some (Cstruct.to_string buf)
 
     let bundle ~tracking_branch commit =
-      let head = id commit in
+      let head = id commit in (* commit id *)
       I.of_branch_id commit.repo.task_maker tracking_branch commit.repo.r >>= fun s ->
       let s = s "bundle" in
       I.head s >>= function

--- a/utils/git_storage.mli
+++ b/utils/git_storage.mli
@@ -3,7 +3,8 @@
 
 (** A Git-like storage abstraction over Irmin. *)
 
-module Make (I : Irmin.S with type key = string list and type value = string) : sig
+module Make (I : Irmin.S with type key = string list and type value = string and
+            type commit_id = Irmin.Hash.SHA1.t and type branch_id = string) : sig
   include Git_storage_s.S
 
   val make : Irmin.config -> (string -> Irmin.task) -> Repository.t Lwt.t

--- a/utils/git_storage.mli
+++ b/utils/git_storage.mli
@@ -3,7 +3,7 @@
 
 (** A Git-like storage abstraction over Irmin. *)
 
-module Make (I : Irmin.BASIC with type key = string list and type value = string) : sig
+module Make (I : Irmin.S with type key = string list and type value = string) : sig
   include Git_storage_s.S
 
   val make : Irmin.config -> (string -> Irmin.task) -> Repository.t Lwt.t


### PR DESCRIPTION
These changes allow Cuekeeper to be built with the current versions of Irmin and js_of_ocaml (0.10.1 and 2.7, respectively).
