### PR TITLE
Fix `setSelectionRange` arguments

### DIFF
--- a/js/ck_template.ml
+++ b/js/ck_template.ml
@@ -854,7 +854,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
               let elem = Tyxml_js.To_dom.of_textarea value in
               elem##focus;
               let len = String.length descr in
-              (Obj.magic elem)##setSelectionRange (len, len);
+              (Obj.magic elem)##setSelectionRange len len;
               Lwt.return ()
             );
             let submit _ev =


### PR DESCRIPTION
js_of_ocaml 2.8.2 generates an array for a tuple argument given to
`##setSelectionRange`, producing a runtime error when an action is
edited.

![cuekeeper_error](https://cloud.githubusercontent.com/assets/470210/18961035/f21f118a-866b-11e6-9f49-b1997a9806dd.png)
