### PR TITLE
Modernise build slightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: c
-script: make docker-build
+script:
+  - echo 'COPY --chown=opam . .' >> Dockerfile
+  - echo 'RUN opam config exec -- make' >> Dockerfile
+  - docker build .
 sudo: required
 dist: trusty
 services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM debian:stretch
+FROM ocaml/opam2:debian-10-opam@sha256:79636246d69ee9d285c87af8a078d2dcc1c893d75e40c581da3284da6cf1841c
+#FROM ocaml/opam2:debian-10-opam
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update && apt-get -y upgrade && apt-get -y install aspcud zip m4 autoconf opam build-essential gcc-multilib ca-certificates git rsync time --no-install-recommends
-RUN opam init --comp=4.04.2+32bit
+RUN sudo apt-get -y update && sudo apt-get -y install aspcud zip m4 autoconf build-essential gcc-multilib ca-certificates git rsync time --no-install-recommends
+RUN opam init --comp=4.04.2+32bit --disable-sandboxing
 RUN opam pin add -n reactiveData https://github.com/hhugo/reactiveData.git
-ADD opam /home/opam/cuekeeper/opam
+RUN mkdir /home/opam/cuekeeper
+COPY --chown=opam opam /home/opam/cuekeeper/opam
 WORKDIR /home/opam/cuekeeper
-RUN opam pin add -n -y cuekeeper .
-RUN opam install -y mirage-types-lwt mirage-http ocamlbuild 'conduit=0.13.0' 'lwt<2.7.0' camlp4 react
-RUN opam install -y --deps-only cuekeeper
+RUN opam install --solver=aspcud -y -t --deps-only .
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/opam
+++ b/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-http" {test}
   "mirage-types-lwt" {test}
   "ppx_sexp_conv"
-  "lwt" {< "2.7.0"}
+  "lwt"
   "cstruct" {>= "1.7.0"}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Use the `ocaml/opam2:debian-10-opam` image to get opam 2 and use that to simplify the installation a little.

The lwt problem has now been fixed in opam-repository.

As the build now runs as "opam", just add the build command to the Dockerfile in the Travis tests.

Note: we still use aspcud, to avoid solver timeouts.