### PR TITLE
Upgrade lots of dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM ocaml/opam2:debian-10-opam@sha256:79636246d69ee9d285c87af8a078d2dcc1c893d75
 #FROM ocaml/opam2:debian-10-opam
 ENV DEBIAN_FRONTEND=noninteractive
 RUN sudo apt-get -y update && sudo apt-get -y install aspcud zip m4 autoconf build-essential gcc-multilib ca-certificates git rsync time --no-install-recommends
-RUN opam init --comp=4.04.2+32bit --disable-sandboxing
+RUN opam init --comp=4.05.0+32bit --disable-sandboxing
 RUN opam pin add -n reactiveData https://github.com/hhugo/reactiveData.git
+RUN opam pin add -n irmin.0.10.1 https://github.com/talex5/irmin.git#cuekeeper
+RUN opam pin add -n irmin-indexeddb.0.5 https://github.com/talex5/irmin-indexeddb.git#v0.5
 RUN mkdir /home/opam/cuekeeper
 COPY --chown=opam opam /home/opam/cuekeeper/opam
 WORKDIR /home/opam/cuekeeper

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build-byte: ck_init.ml
 	ocamlbuild -cflag -g -no-links -use-ocamlfind client.byte
 
 _build/js/client.js: build-byte
-	js_of_ocaml ${JFLAGS} +weak.js +cstruct/cstruct.js +bin_prot.js _build/js/client.byte
+	js_of_ocaml ${JFLAGS} +cstruct/cstruct.js js/helpers.js _build/js/client.byte
 
 slow_test:
 	ocamlbuild -cflag -g -no-links -use-ocamlfind tests/test.native

--- a/README.md
+++ b/README.md
@@ -106,12 +106,7 @@ Make sure the `None` line comes last - this rejects all unknown tokens.
 
 To build the server component:
 
-    opam pin add mirage 2.9.1
-    opam pin add mirage-console 2.1.3
-    opam pin add crunch 1.4.1
-    opam pin add tcpip 2.8.1
-    opam pin add mirage-logs 0.2
-    opam pin add shared-memory-ring 1.3.0
+    opam pin add mirage 3.4.1
     make server
 
 You will be prompted to create a self-signed X.509 certificate. Just enter your server's hostname

--- a/_tags
+++ b/_tags
@@ -1,8 +1,8 @@
 true: strict_sequence, bin_annot, warn(A-4-44-48)
-true: package(irmin,lwt,sexplib,uuidm,irmin.mem,irmin-indexeddb,base64,ocamlgraph,reactiveData,omd,tar,cohttp.lwt)
+true: package(irmin,lwt,sexplib,uuidm,irmin.mem,irmin-indexeddb,base64,ocamlgraph,reactiveData,omd,tar,cohttp,cohttp-lwt)
 <lib/*>: package(ppx_sexp_conv)
-<tests/*>: package(oUnit, lwt.unix, mirage-types, mirage-http)
-<js/*>: package(js_of_ocaml.ppx,js_of_ocaml,js_of_ocaml.tyxml,cohttp.js)
+<tests/*>: package(oUnit, lwt.unix, cohttp-lwt)
+<js/*>: package(js_of_ocaml-ppx,js_of_ocaml,js_of_ocaml-tyxml,js_of_ocaml-lwt,cohttp-lwt-jsoo)
 true: debug
 <js>: include
 <lib>: include

--- a/js/ck_animate.ml
+++ b/js/ck_animate.ml
@@ -1,6 +1,11 @@
 (* Copyright (C) 2015, Thomas Leonard
  * See the README file for details. *)
 
+open Js_of_ocaml
+open Js_of_ocaml_tyxml
+module Lwt_js = Js_of_ocaml_lwt.Lwt_js
+module Lwt_js_events = Js_of_ocaml_lwt.Lwt_js_events
+
 (* Ck_model gives us 1s for the whole fade-out, resize, fade-in sequence *)
 let fade_time = 0.33
 let resize_time = 0.33

--- a/js/ck_authn_RPC.ml
+++ b/js/ck_authn_RPC.ml
@@ -4,6 +4,7 @@
 (* RPC over XMLHttpRequest, getting the access token from the user if necessary. *)
 
 open Lwt
+open Js_of_ocaml
 
 module XHR = Cohttp_lwt_xhr.Client
 

--- a/js/ck_js_utils.ml
+++ b/js/ck_js_utils.ml
@@ -1,6 +1,10 @@
 (* Copyright (C) 2015, Thomas Leonard
  * See the README file for details. *)
 
+open Js_of_ocaml
+open Js_of_ocaml_tyxml
+module Lwt_js_events = Js_of_ocaml_lwt.Lwt_js_events
+
 let ignore_listener = ignore
 
 let inside elem child =

--- a/js/ck_js_utils.mli
+++ b/js/ck_js_utils.mli
@@ -1,6 +1,9 @@
 (* Copyright (C) 2015, Thomas Leonard
  * See the README file for details. *)
 
+open Js_of_ocaml
+open Js_of_ocaml_tyxml
+
 val ignore_listener : Dom_html.event_listener_id -> unit
 (** Version of [ignore] restricted to event listeners. *)
 

--- a/js/ck_modal.ml
+++ b/js/ck_modal.ml
@@ -1,6 +1,7 @@
 (* Copyright (C) 2015, Thomas Leonard
  * See the README file for details. *)
 
+open Js_of_ocaml
 open Ck_js_utils
 
 type t = {

--- a/js/ck_modal.mli
+++ b/js/ck_modal.mli
@@ -6,6 +6,8 @@
  * - escape is pressed, or
  * - the user clicks outside the modal element *)
 
+open Js_of_ocaml
+
 val show : close:(unit -> unit) -> #Dom_html.element Js.t -> unit
 (** Show a new modal (closing any currently-open one first). *)
 

--- a/js/ck_panel.ml
+++ b/js/ck_panel.ml
@@ -1,7 +1,10 @@
 (* Copyright (C) 2015, Thomas Leonard
  * See the README file for details. *)
 
-open Tyxml_js
+open Js_of_ocaml_tyxml.Tyxml_js
+module Tyxml_js = Js_of_ocaml_tyxml.Tyxml_js
+module Lwt_js_events = Js_of_ocaml_lwt.Lwt_js_events
+module Lwt_js = Js_of_ocaml_lwt.Lwt_js
 open Html5
 open Ck_utils
 open Lwt

--- a/js/ck_panel.mli
+++ b/js/ck_panel.mli
@@ -1,7 +1,7 @@
 (* Copyright (C) 2015, Thomas Leonard
  * See the README file for details. *)
 
-open Tyxml_js
+open Js_of_ocaml_tyxml.Tyxml_js
 
 type t
 

--- a/js/ck_template.ml
+++ b/js/ck_template.ml
@@ -1,8 +1,10 @@
 (* Copyright (C) 2015, Thomas Leonard
  * See the README file for details. *)
 
-open Tyxml_js
-open Html5
+open Js_of_ocaml
+open Js_of_ocaml_tyxml
+open Js_of_ocaml_tyxml.Tyxml_js
+open Js_of_ocaml_tyxml.Tyxml_js.Html5
 open Ck_utils
 open Ck_js_utils
 
@@ -84,10 +86,10 @@ let current_error, set_current_error = React.S.create None
 let make_error_box error =
   error
   |> React.S.map (function
-    | None -> pcdata ""
+    | None -> txt ""
     | Some err ->
         div ~a:[a_class ["ck-bug"; "alert-box"; "alert"]] [
-          p [pcdata err]; p [pcdata "Refresh this page to continue."];
+          p [txt err]; p [txt "Refresh this page to continue."];
         ]
   )
   |> ReactiveData.RList.singleton_s
@@ -109,7 +111,7 @@ let a_onsubmit fn =
       false
   )
 
-let ck_label s = span ~a:[a_class ["ck-label"]] [pcdata s]
+let ck_label s = span ~a:[a_class ["ck-label"]] [txt s]
 
 let (>>?=) = Js.Opt.bind
 
@@ -147,7 +149,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       async ~name:"waiting" (fun () -> M.set_action_state m action `Waiting);
       Ck_modal.close ();
       false in
-    let waiting = li [a ~a:[a_onclick wait_unspec] [pcdata "Waiting (reason unspecified)"]] in
+    let waiting = li [a ~a:[a_onclick wait_unspec] [txt "Waiting (reason unspecified)"]] in
     match M.Item.contact_node action with
     | None -> [waiting]
     | Some contact ->
@@ -156,7 +158,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
           Ck_modal.close ();
           false in
         let name = M.Item.name contact in
-        let waiting_for = li [a ~a:[a_onclick clicked] [pcdata ("Waiting for " ^ name)]] in
+        let waiting_for = li [a ~a:[a_onclick clicked] [txt ("Waiting for " ^ name)]] in
         [waiting_for; waiting]
 
   let is_repeat_action = function
@@ -173,7 +175,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       | `Active -> "a", "Active"
       | `SomedayMaybe -> "sm", "Someday/Maybe" in
     if l = "✓" && is_repeat_action item then
-      span ~a:[a_class ["ck-toggle-hidden"]] [span [pcdata l]]
+      span ~a:[a_class ["ck-toggle-hidden"]] [span [txt l]]
     else (
       let cl =
         if due && l = "w" then "ck-active-alert"
@@ -181,7 +183,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       let changed ev =
         set_details ev details;
         true in
-      a ~a:[a_class [cl]; a_onclick changed; a_title title] [pcdata l]
+      a ~a:[a_class [cl]; a_onclick changed; a_title title] [txt l]
     )
 
   let make_toggles ~m ~set_details ~item ?(due=false) current options =
@@ -191,7 +193,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
     let set_star _ev =
       async ~name:"set_starred" (fun () -> M.set_starred m item (not starred));
       true in
-    let star = a ~a:[a_class [cl]; a_onclick set_star] [pcdata "★"] in
+    let star = a ~a:[a_class [cl]; a_onclick set_star] [txt "★"] in
     state_toggles @ [star]
 
   let due action =
@@ -216,7 +218,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
           if n = `Waiting then (
             let content = div [
               wait_until_date m item;
-              div ~a:[a_class ["ck-or"]] [pcdata "or"];
+              div ~a:[a_class ["ck-or"]] [txt "or"];
               ul ~a:[a_class ["ck-waiting-menu"]] (waiting_candidates m item)
             ] in
             show_modal ~parent:(ev##.target) [content];
@@ -304,7 +306,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
         let close _ev = Ck_modal.close (); false in
         let content =
           div ~a:[a_class ["alert-box"]; a_onclick close] [
-            pcdata msg;
+            txt msg;
           ] in
         show_modal ~parent [content]
 
@@ -316,7 +318,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
           false in
         span [
           item_span;
-          a ~a:[a_class ["ck-add-child"]; a_onclick add_clicked] [pcdata "+"]
+          a ~a:[a_class ["ck-add-child"]; a_onclick add_clicked] [txt "+"]
         ]
     | _ -> span [item_span]
 
@@ -326,18 +328,18 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
     span ~a:[a_class item_cl] [
       span ~a:[a_class ["ck-toggles"]] (toggles_for_type m item);
       span ~a:[a_class ["allow-strikethrough"]] [   (* CSS hack to allow strikethrough and underline together *)
-        a ~a:[a_class ["ck-title"]; a_onclick clicked] [pcdata (M.Item.name item)];
+        a ~a:[a_class ["ck-title"]; a_onclick clicked] [txt (M.Item.name item)];
       ];
     ]
     |> with_adder m ?adder ~show_node
 
   let render_group_item m ?adder ~show_node item =
     let clicked _ev = show_node (item :> M.Item.generic); false in
-    a ~a:[a_onclick clicked; a_class ["ck-group-label"]] [pcdata (M.Item.name item)]
+    a ~a:[a_onclick clicked; a_class ["ck-group-label"]] [txt (M.Item.name item)]
     |> with_adder m ?adder ~show_node
 
   let group_label m ?adder ~show_node s =
-    span ~a:[a_class ["ck-group-label"]] [pcdata s]
+    span ~a:[a_class ["ck-group-label"]] [txt s]
     |> with_adder m ?adder ~show_node
 
   (* A <li>[toggles] name x [children]</li> element *)
@@ -375,7 +377,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
             false in
           let cl = if active then ["active"] else [] in
           li ~a:[a_class cl] [
-            a ~a:[a_onclick toggle] [pcdata (M.Item.name item)]
+            a ~a:[a_onclick toggle] [txt (M.Item.name item)]
           ]
         )
       ) |> rlist_of in
@@ -395,8 +397,8 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
               false in
             let name = item >|~= M.Item.name in
             span [
-              a ~a:[a_class ["ck-group"]; a_onclick show_group] [R.Html5.pcdata name];
-              a ~a:[a_class ["ck-add-child"]; a_onclick add_clicked] [pcdata "+"];
+              a ~a:[a_class ["ck-group"]; a_onclick show_group] [R.Html5.txt name];
+              a ~a:[a_class ["ck-add-child"]; a_onclick add_clicked] [txt "+"];
             ]
         | `Group label -> group_label m ?adder:(W.adder group) ~show_node label in
       animated group [
@@ -411,13 +413,13 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       | _ -> assert false in
     let heading ?adder widget =
       match W.item widget, adder with
-      | `Item _, _ -> pcdata "ERROR: not a heading!"
-      | `Group label, None -> h4 [pcdata label]
+      | `Item _, _ -> txt "ERROR: not a heading!"
+      | `Group label, None -> h4 [txt label]
       | `Group label, Some adder ->
           let add_clicked ev =
             show_add_modal ~show_node ~button:(ev##.target) adder;
             false in
-          h4 [pcdata label; a ~a:[a_class ["ck-add-child"]; a_onclick add_clicked] [pcdata "+"]] in
+          h4 [txt label; a ~a:[a_class ["ck-add-child"]; a_onclick add_clicked] [txt "+"]] in
     let next_children = W.children groups |> ReactiveData.RList.map make_work_actions in
     let done_children = W.children done_actions |> ReactiveData.RList.map (make_tree_node_view m ~show_node) in
     [
@@ -468,7 +470,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       | _ -> [] in
     let item =
       li ~a:[R.Html5.a_class cl] [
-        a ~a:[a_onclick view; R.Html5.a_class a_cl] [pcdata (date ^ ": " ^ summary)];
+        a ~a:[a_onclick view; R.Html5.a_class a_cl] [txt (date ^ ": " ^ summary)];
       ] in
     item_ref := Some item;
     item
@@ -508,7 +510,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       show_add_contact m ~show_node ~parent:ev##.target;
       false in
     [
-      h4 [pcdata "Contacts"; a ~a:[a_class ["ck-add-child"]; a_onclick add_clicked] [pcdata "+"]];
+      h4 [txt "Contacts"; a ~a:[a_class ["ck-add-child"]; a_onclick add_clicked] [txt "+"]];
       R.Html5.ul ~a:[a_class ["ck-contacts"]] (
         ReactiveData.RList.map (make_tree_node_view m ~show_node) tree
       )
@@ -539,7 +541,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       show_modal ~parent:(ev##.target) [content];
       false in
     [
-      h4 [pcdata "Schedule"; a ~a:[a_class ["ck-add-child"]; a_onclick add_clicked] [pcdata "+"]];
+      h4 [txt "Schedule"; a ~a:[a_class ["ck-add-child"]; a_onclick add_clicked] [txt "+"]];
       R.Html5.ul (
         ReactiveData.RList.map (make_tree_node_view m ~show_node) tree
       )
@@ -548,7 +550,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
   let review_mode_switcher ~current m =
     let item mode label =
       let clicked _ev = M.set_review_mode m mode; false in
-      div [radio_button ~clicked ~checked:(mode = current); pcdata label] in
+      div [radio_button ~clicked ~checked:(mode = current); txt label] in
     form ~a:[a_class ["ck-review-mode"]] [
       item `Done "Done";
       item `Waiting "Waiting";
@@ -568,7 +570,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
     let delete_done _ev =
       async ~name:"delete_done" (fun () -> M.delete_done m);
       false in
-    button ~a:[a_onclick delete_done] [pcdata "Delete done items"]
+    button ~a:[a_onclick delete_done] [txt "Delete done items"]
 
   let make_tree ~show_node m = function
     | `Process tree -> make_process_view m ~show_node tree
@@ -609,7 +611,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       ) in
       let cl = R.Html5.a_class (React.S.l2 (@) alert_attr active_attr) in
       let button = a ~a:[a_onclick clicked]
-        [pcdata (String.sub name 0 1); span ~a:[a_class ["ck-long-label"]] [pcdata (tail name 1)]] in
+        [txt (String.sub name 0 1); span ~a:[a_class ["ck-long-label"]] [txt (tail name 1)]] in
       li ~a:[cl] [button] in
     ul ~a:[a_class ["ck-mode-selector"]] [
       item "Process" `Process;
@@ -651,16 +653,16 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       let start_editing (_:#Dom_html.event Js.t) =
         set_editing (Some adder);
         true in
-      li [a ~a:[a_onclick start_editing] [pcdata label]] in
+      li [a ~a:[a_onclick start_editing] [txt label]] in
     let widgets =
       editing >>~= (function
         (* When we're not editing, display the add buttons. *)
         | None ->
             item >|~= (function
-              | None -> pcdata ""
+              | None -> txt ""
               | Some item ->
                   match item with
-                  | `Action _ | `Contact _ | `Context _ -> pcdata ""
+                  | `Action _ | `Contact _ | `Context _ -> txt ""
                   | `Project _ as item -> ul ~a:[a_class ["ck-adders"]] [
                       add_button (M.add_project m ~state:`Active ~parent:item) "+sub-project";
                       add_button (M.add_action m ~state:`Next ~parent:item ?context:None ?contact:None) "+action";
@@ -696,7 +698,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
               true in
             [
               span ~a:[a_class ["allow-strikethrough"]] [   (* CSS hack to allow strikethrough and underline together *)
-                a ~a:[a_class ["ck-title"]; a_onclick edit] [R.Html5.pcdata name];
+                a ~a:[a_class ["ck-title"]; a_onclick edit] [R.Html5.txt name];
               ]
             ]
         | Some item ->
@@ -735,7 +737,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
         true in
       li [
         a ~a:[a_onclick clicked] [
-          pcdata (M.candidate_label candidate)
+          txt (M.candidate_label candidate)
         ]
       ]
     )
@@ -746,7 +748,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
         Ck_modal.close ();
         async ~name:label (fun () -> fn m item >|= report_error ~parent:button);
         false in
-      li [a ~a:[a_onclick clicked] [pcdata label]] in
+      li [a ~a:[a_onclick clicked] [txt label]] in
     let content = ul (
       match item with
       | `Action _ as item -> [make "Convert to project" M.convert_to_project item]
@@ -761,15 +763,15 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       edit ev;
       false in
     match current with
-    | None -> [a ~a:[a_onclick clicked] [pcdata if_none]]
+    | None -> [a ~a:[a_onclick clicked] [txt if_none]]
     | Some current ->
         let current = (current :> M.Item.generic) in
         let cl = ["ck-item"; class_of_node_type current] in
         let show_clicked _ev = show_node current; false in
-        let show_button = a ~a:[a_onclick show_clicked] [pcdata " (show)"] in
+        let show_button = a ~a:[a_onclick show_clicked] [txt " (show)"] in
         [
           span ~a:[a_class cl] [
-            a ~a:[a_class ["ck-title"]; a_onclick clicked] [pcdata (M.Item.name current)]
+            a ~a:[a_class ["ck-title"]; a_onclick clicked] [txt (M.Item.name current)]
           ];
           show_button;
         ]
@@ -778,7 +780,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
     let pair = React.S.l2 ~eq:assume_changed (fun a b -> (a, b)) details.M.details_item details.M.details_parent in
     rlist_of (pair >|~= fun (item, parent) ->
       match item with
-      | None -> [pcdata "(deleted)"]
+      | None -> [txt "(deleted)"]
       | Some item ->
       let make_parent item =
         let edit ev =
@@ -791,7 +793,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
           let change_type label =
             let on_click ev =
               show_type_modal m ~button:(ev##.target) item; false in
-            a ~a:[a_onclick on_click] [pcdata label] in
+            a ~a:[a_onclick on_click] [txt label] in
           match item with
           | `Action _ -> ck_label "An " :: change_type "action" :: ck_label " in " :: make_parent item
           | `Project _ -> ck_label "A " :: change_type "project" :: ck_label " in " :: make_parent item
@@ -825,10 +827,10 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
                   let buttons =
                     div ~a:[a_class ["row"]] [
                       div ~a:[a_class ["small-6"; "columns"; "ck-add-log"]] [
-                        a ~a:[a_onclick append_log] [pcdata "(add log entry)"];
+                        a ~a:[a_onclick append_log] [txt "(add log entry)"];
                       ];
                       div ~a:[a_class ["small-6"; "columns"; "ck-edit"]] [
-                        a ~a:[a_onclick edit] [pcdata "(edit)"];
+                        a ~a:[a_onclick edit] [txt "(edit)"];
                       ]
                     ] in
                   try
@@ -840,7 +842,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
                       [description; buttons]
                     ) else [buttons]
                   with ex ->
-                    [div [pcdata (Printexc.to_string ex)]; buttons]
+                    [div [txt (Printexc.to_string ex)]; buttons]
             );
         | Some (item, descr) ->
             let cancel _ev = set_editing None; false in
@@ -849,7 +851,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
               if ev##.keyCode = 13 && Js.to_bool ev##.ctrlKey then (!submit_ref ev; false)
               else true in
             let value = textarea ~a:[a_rows 5; a_onkeydown keydown]
-              (pcdata descr) in
+              (txt descr) in
             async ~name:"focus" (fun () ->
               let elem = Tyxml_js.To_dom.of_textarea value in
               elem##focus;
@@ -867,7 +869,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
               form ~a:[a_onsubmit submit] [
                 value;
                 div ~a:[a_class ["actions"]] [
-                  a ~a:[a_onclick cancel] [pcdata "(cancel) "];
+                  a ~a:[a_onclick cancel] [txt "(cancel) "];
                   submit_button "OK";
                 ]
               ]
@@ -912,7 +914,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
               M.choose_candidate candidate
             );
             false in
-          li [a ~a:[a_onclick select] [pcdata (M.candidate_label candidate)]]
+          li [a ~a:[a_onclick select] [txt (M.candidate_label candidate)]]
         ) in
         let content = ul (new_contact_form :: contexts) in
         show_modal ~parent:(ev##.target) [content]
@@ -945,7 +947,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
               M.choose_candidate candidate
             );
             false in
-          li [a ~a:[a_onclick select] [pcdata (M.candidate_label candidate)]]
+          li [a ~a:[a_onclick select] [txt (M.candidate_label candidate)]]
         ) in
         let content = ul (new_contact_form :: contacts) in
         show_modal ~parent:(ev##.target) [content]
@@ -970,7 +972,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       let unit_option u =
         let attrs =
           if u = init.repeat_unit then [a_selected ()] else [] in
-        option ~a:attrs (pcdata ((string_of_time_unit u) ^ "s")) in
+        option ~a:attrs (txt ((string_of_time_unit u) ^ "s")) in
       select (unit_options |> Array.map unit_option |> Array.to_list) in
     let on_select date =
       let input_elem = To_dom.of_input n_input in
@@ -1012,7 +1014,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
     let clear _ev =
       async ~name:"clear_repeat" (fun () -> M.set_repeat m action None);
       false in
-    a ~a:[a_onclick clear; a_class ["delete"]] [pcdata "×"]
+    a ~a:[a_onclick clear; a_class ["delete"]] [txt "×"]
 
   let make_conflicts m item =
     item >|~= function
@@ -1027,11 +1029,11 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
         [
           div ~a:[a_class ["ck-conflicts"]] [
             div ~a:[a_class ["ck-box-title"]] [
-              h4 [pcdata "Merge conflicts"];
-              a ~a:[a_class ["close"]; a_onclick clear_conflicts] [pcdata "×"];
+              h4 [txt "Merge conflicts"];
+              a ~a:[a_class ["close"]; a_onclick clear_conflicts] [txt "×"];
             ];
             ul (
-              ms |> List.map (fun msg -> li [pcdata msg])
+              ms |> List.map (fun msg -> li [txt msg])
             )
           ]
         ]
@@ -1071,7 +1073,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
               match M.Item.action_state action with
               | `Waiting_until time ->
                   let clicked ev = edit_date ~ev m action; false in
-                  [ck_label "Waiting until "; a ~a:[a_onclick clicked] [pcdata (Ck_time.string_of_user_date time)]]
+                  [ck_label "Waiting until "; a ~a:[a_onclick clicked] [txt (Ck_time.string_of_user_date time)]]
               | _ -> [] in
             let repeating, clear =
               match M.Item.action_repeat action with
@@ -1082,7 +1084,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
               div (
                 [
                   ck_label "Repeats: ";
-                  a ~a:[a_onclick (edit_repeat m action)] [pcdata repeating];
+                  a ~a:[a_onclick (edit_repeat m action)] [txt repeating];
                 ] @ clear
               )
             ]
@@ -1102,7 +1104,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
               make_node_chooser ~edit ~show_node ~if_none:"(no contact)" opt_contact
             ) |> rlist_of in
           [
-            span ~a:[a_class ["ck-label"]] [R.Html5.pcdata label];
+            span ~a:[a_class ["ck-label"]] [R.Html5.txt label];
             R.Html5.span value;
           ] in
     let context =
@@ -1131,7 +1133,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
           | _ -> "Created " in
         div [
           ck_label (created_msg ^ ctime);
-          a ~a:[a_onclick delete_clicked; a_class ["ck-delete"]] [pcdata " (delete)"];
+          a ~a:[a_onclick delete_clicked; a_class ["ck-delete"]] [txt " (delete)"];
         ];
       ] in
     (title, div contents)
@@ -1152,7 +1154,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       false in
     li [
       span ~a:[a_class cl] [
-        a ~a:[a_class ["ck-title"]; a_onclick clicked] [pcdata (M.Item.name item)]
+        a ~a:[a_class ["ck-title"]; a_onclick clicked] [txt (M.Item.name item)]
       ]
     ]
 
@@ -1214,7 +1216,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
         add (M.add_action ~state:`Next ?context:None ?contact:None ?parent:None ?description:None) ev in
     my_input := Some input_box;
     let action adder label =
-      li [a ~a:[a_onclick (fun ev -> add adder ev; false)] [pcdata label]] in
+      li [a ~a:[a_onclick (fun ev -> add adder ev; false)] [txt label]] in
     let f = form ~a:[a_onsubmit submit; a_class ["ck-main-entry"]] [
       input_box;
       div ~a:[R.Html5.a_class cl] [
@@ -1267,7 +1269,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
       ) in
     let show_history () =
       show_or_create history_uuid (fun closed set_closed ->
-        let title = b [pcdata "History"] in
+        let title = b [txt "History"] in
         let contents = make_sync m in
         let on_destroy () =
           remove history_uuid;
@@ -1301,22 +1303,22 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
           showing := true;
           [
             div ~a:[a_class cl] [
-              p [pcdata (
+              p [txt (
                 Printf.sprintf "Time-travel active: you are viewing the state of CueKeeper as at %s."
                   (Ck_time.string_of_unix_time log_entry.Git_storage_s.Log_entry.date)
               )];
               p [
-                button ~a:[a_onclick revert] [pcdata "Revert this change"];
-                pcdata msg;
+                button ~a:[a_onclick revert] [txt "Revert this change"];
+                txt msg;
               ];
-              a ~a:[a_class ["close"]; a_onclick return_to_present] [pcdata "×"]
+              a ~a:[a_class ["close"]; a_onclick return_to_present] [txt "×"]
             ]
           ]
     )
     |> rlist_of
 
   let export m ev =
-    let s, set_s = React.S.create (pcdata "Exporting...") in
+    let s, set_s = React.S.create (txt "Exporting...") in
     async ~name:"export" (fun () ->
       M.export_tar m >|= fun data ->
       let data = make_blob ~mime:"application/x-tar" data in
@@ -1325,7 +1327,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
         save_as data name;
         Ck_modal.close ();
         false in
-      set_s (a ~a:[a_onclick download] [pcdata name])
+      set_s (a ~a:[a_onclick download] [txt name])
     );
     [R.Html5.div ~a:[a_class ["ck-export"]] (ReactiveData.RList.singleton_s s)]
     |> show_modal ~parent:(ev##.target);
@@ -1341,9 +1343,9 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
     let current_tree = M.tree m in
     let details_area, show_node, show_history, close_all = make_details_area m in
     let actions = [
-      a ~a:[a_onclick (export m)] [pcdata "Export"];
-      a ~a:[a_onclick (fun _ -> show_history (); false)] [pcdata "Show history"];
-      a ~a:[a_onclick (fun _ -> close_all (); false)] [pcdata "Close all"];
+      a ~a:[a_onclick (export m)] [txt "Export"];
+      a ~a:[a_onclick (fun _ -> show_history (); false)] [txt "Show history"];
+      a ~a:[a_onclick (fun _ -> close_all (); false)] [txt "Close all"];
     ] in
     let actions =
       match M.client m with
@@ -1352,7 +1354,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
             | false -> []
             | true -> ["ck-in-progress"]
           ) in
-          a ~a:[a_onclick (sync client); R.Html5.a_class cl] [pcdata "Sync"] :: actions
+          a ~a:[a_onclick (sync client); R.Html5.a_class cl] [txt "Sync"] :: actions
       | None -> actions in
     let left_panel =
       let live = current_tree >|~= make_tree ~show_node m in

--- a/js/ck_template.mli
+++ b/js/ck_template.mli
@@ -2,6 +2,7 @@
  * See the README file for details. *)
 
 open Ck_sigs
+open Js_of_ocaml_tyxml
 
 module Gui_tree_data : GUI_DATA
 

--- a/js/client.ml
+++ b/js/client.ml
@@ -3,6 +3,11 @@
 
 open Lwt
 open Ck_utils
+open Js_of_ocaml
+open Js_of_ocaml_tyxml
+
+module Lwt_js = Js_of_ocaml_lwt.Lwt_js
+module Lwt_js_events = Js_of_ocaml_lwt.Lwt_js_events
 
 (* let () = Log.(set_log_level INFO) *)
 
@@ -58,7 +63,7 @@ let start (main:#Dom.node Js.t) =
           msg ^ " Ensure cookies are enabled (needed to access local storage)."
         else msg in
       let error = Tyxml_js.Html5.(div ~a:[a_class ["alert-box"; "alert"]]
-                                    [pcdata msg]) in
+                                    [txt msg]) in
       main##appendChild (Tyxml_js.To_dom.of_node error) |> ignore;
       raise ex
     )

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,0 +1,32 @@
+// TODO: These should have proper bounds checks.
+
+//Provides: bin_prot_get_float_offset
+//Requires: caml_float_of_bytes, caml_ba_get_1
+// (rescued from
+//  https://github.com/ocsigen/js_of_ocaml/commit/347bced8f43000f63ada887151381e7a64140578)
+function bin_prot_get_float_offset(a,p){
+  var t = new Array(8);;
+  for (var i = 0;i < 8;i++) t[7-i] = caml_ba_get_1(a,p++);
+  var v = caml_float_of_bytes (t);
+  return [254,v];
+}
+
+//Provides: bin_prot_blit_string_buf_stub
+//Requires: caml_blit_string_to_bigstring
+function bin_prot_blit_string_buf_stub(ofs1, buf1, ofs2, buf2, len) {
+	caml_blit_string_to_bigstring(buf1, ofs1, buf2, ofs2, len)
+}
+
+//Provides: bin_prot_blit_buf_string_stub
+//Requires: caml_blit_bigstring_to_string
+function bin_prot_blit_buf_string_stub(ofs1, buf1, ofs2, buf2, len) {
+	caml_blit_bigstring_to_string(buf1, ofs1, buf2, ofs2, len)
+}
+
+//Provides: bin_prot_blit_buf_stub
+//Requires: caml_ba_sub, caml_ba_blit
+function bin_prot_blit_buf_stub(ofs1, buf1, ofs2, buf2, len) {
+	var src = caml_ba_sub(buf1, ofs1, len)
+	var dst = caml_ba_sub(buf2, ofs2, len)
+	caml_ba_blit(src, dst)
+}

--- a/js/pikaday.ml
+++ b/js/pikaday.ml
@@ -4,7 +4,8 @@
 (** Bindings for Pikadate.
  * See https://github.com/dbushell/Pikaday/ *)
 
-open Tyxml_js
+open Js_of_ocaml
+open Js_of_ocaml_tyxml.Tyxml_js
 
 class type pikaday =
   object
@@ -31,7 +32,7 @@ let to_user_date d =
 
 let make ?(initial:Ck_time.user_date option) ~on_select () =
   let div = Html5.div [] in
-  let elem = Tyxml_js.To_dom.of_div div in
+  let elem = To_dom.of_div div in
   let config = make_config () in
   config##.container := elem;
   config##.onSelect := Js.wrap_callback (fun d ->

--- a/lib/ck_sigs.ml
+++ b/lib/ck_sigs.ml
@@ -156,10 +156,10 @@ module type RPC = sig
 
   val get :
     ?headers:Cohttp.Header.t ->
-    Uri.t -> (Response.t * Cohttp_lwt_body.t) or_cancelled Lwt.t
+    Uri.t -> (Response.t * Cohttp_lwt.Body.t) or_cancelled Lwt.t
 
   val post :
-    ?body:Cohttp_lwt_body.t ->
+    ?body:Cohttp_lwt.Body.t ->
     ?headers:Cohttp.Header.t ->
-    Uri.t -> (Response.t * Cohttp_lwt_body.t) or_cancelled Lwt.t
+    Uri.t -> (Response.t * Cohttp_lwt.Body.t) or_cancelled Lwt.t
 end

--- a/opam
+++ b/opam
@@ -21,27 +21,20 @@ depends: [
   "irmin"
   "tyxml"
   "reactiveData"
-  "js_of_ocaml"
+  "js_of_ocaml" {>= "3.0.0"}
+  "js_of_ocaml-tyxml"
   "omd"
   "ounit" {build}
-  "tar-format" {>= "0.6.0" & < "0.7.1"}
+  "tar"
   "cohttp"
+  "cohttp-lwt-jsoo"
   "irmin-indexeddb" {>= "0.3"}
   "crunch" {build}
   "ocamlfind" {build}
-  "mirage-http" {test}
-  "mirage-types-lwt" {test}
   "ppx_sexp_conv"
   "lwt"
   "cstruct" {>= "1.7.0"}
+  "bin_prot" {< "114.03"}
+  "ppx_deriving"
   "ocamlbuild" {build}
-]
-depopts: [
-  "mirage"
-]
-conflicts: [
-  "mirage-xen-posix" {< "2.3.3"}
-  "conduit" {>= "0.14"}
-  "mirage" {> "2.9.1"}
-  "mirage-types" {> "2.9.1"}
 ]

--- a/server/config.ml
+++ b/server/config.ml
@@ -3,46 +3,20 @@
 
 open Mirage
 
-let net =
-  match get_mode () with
-  | `Xen -> `Direct
-  | `Unix | `MacOSX ->
-      try match Sys.getenv "NET" with
-        | "direct" -> `Direct
-        | "socket" -> `Socket
-        | _        -> `Direct
-      with Not_found -> `Socket
-
-let dhcp =
-  try match Sys.getenv "DHCP" with
-    | "" -> false
-    | _  -> true
-  with Not_found -> true
-
-let ipv4_conf =
-  let i = Ipaddr.V4.of_string_exn in
-  {
-    address  = i "10.0.0.2";
-    netmask  = i "255.255.255.0";
-    gateways = [i "10.0.0.1"];
-  }
-
-let stack console =
-  match net, dhcp with
-  | `Direct, true  -> direct_stackv4_with_dhcp console tap0
-  | `Direct, false -> direct_stackv4_with_static_ipv4 console tap0 ipv4_conf
-  | `Socket, _     -> socket_stackv4 console [Ipaddr.V4.any]
-
 let main =
   foreign
-    ~libraries:["irmin.mem"; "tls.mirage"; "mirage-http"]
-    ~packages:["irmin"; "tls"; "mirage-http"; "nocrypto"]
     ~deps:[abstract nocrypto]
-    "Unikernel.Main" (stackv4 @-> kv_ro @-> clock @-> job)
+    "Unikernel.Main" (stackv4 @-> kv_ro @-> pclock @-> job)
 
 let conf = crunch "conf"
 
+let packages = [
+  package "irmin" ~sublibs:["mem"];
+  package "tls";
+  package "cohttp-mirage";
+]
+
 let () =
-  register "cuekeeper" [
-    main $ stack default_console $ conf $ default_clock
+  register ~packages "cuekeeper" [
+    main $ generic_stackv4 default_network $ conf $ default_posix_clock
   ]

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -21,6 +21,7 @@ module Queue = Lwt_pqueue.Make(struct
   let compare a b =
     compare (fst a) (fst b)
 end)
+[@@warning "-3"]
 
 let debug fmt = Printf.ksprintf ignore fmt
 

--- a/tests/test_net.ml
+++ b/tests/test_net.ml
@@ -9,8 +9,14 @@ module Make(Clock : Ck_clock.S) = struct
   let listener = ref ignore_listener
 
   module Test_network = struct
+    type error = unit
+    let pp_error f () = Format.pp_print_string f "error"
+
     module IO = struct
       include Lwt
+
+      type error = unit
+      let pp_error f () = Format.pp_print_string f "IO error"
 
       type ic = Lwt_io.input_channel
       type oc = Lwt_io.output_channel
@@ -27,6 +33,8 @@ module Make(Clock : Ck_clock.S) = struct
             | ex -> raise ex
           )
       let write = Lwt_io.write
+
+      let catch f = f () >|= fun x -> Ok x
     end
 
     type ctx = unit


### PR DESCRIPTION
CueKeeper has got a bit stuck in a place where upgrading anything seems to require upgrading everything else as well.

- To be able to build with dune, we need `js_of_ocaml >= 3` to get a compatible PPX.

- This required a new irmin-indexeddb and a newer cohttp.

- It also conflicts with Irmin, since the version we need requires the old version of cohttp. I made a fork of the old version with its http support removed (we don't need it anyway).

- The new `cohttp` requires a newer `base64`, which also required updating `irmin-indexeddb`.

- Restore the `bin_prot` JS helpers we removed in c9dfbcdc3f90 because `js_of_ocaml` started providing them, because it has stopped again now:
  https://github.com/ocsigen/js_of_ocaml/commit/347bced8f43000f63ada887151381e7a64140578

- `bin_prot` has started requiring `bin_prot_get_float_offset` for some reason.

- `http-mirage` is deprecated and forced too-old versions. Removed it.

- This all required a newer `cstruct`, which conflicted with `tar-format`. Upgraded to its replacement `tar`.

- Upgraded base compiler to OCaml 4.05.

- Upgraded `mirage` tool to `3.4.1`.