### PR TITLE
Migrate to Git format for storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN sudo apt-get -y update && sudo apt-get -y install aspcud zip m4 autoconf bui
 RUN opam init --comp=4.05.0+32bit --disable-sandboxing
 RUN opam pin add -n reactiveData https://github.com/hhugo/reactiveData.git
 RUN opam pin add -n irmin.0.10.1 https://github.com/talex5/irmin.git#cuekeeper
-RUN opam pin add -n irmin-indexeddb.0.5 https://github.com/talex5/irmin-indexeddb.git#v0.5
+RUN opam pin add -n irmin-indexeddb.0.6 https://github.com/talex5/irmin-indexeddb.git#v0.6
+RUN opam pin add -n git.1.7.1 https://github.com/talex5/ocaml-git.git#cuekeeper
 RUN mkdir /home/opam/cuekeeper
 COPY --chown=opam opam /home/opam/cuekeeper/opam
 WORKDIR /home/opam/cuekeeper

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Pin a few patches we require:
     opam pin add -yn reactiveData https://github.com/hhugo/reactiveData.git
     opam pin add -yn bin_prot.113.33.00+4.05 'https://github.com/talex5/bin_prot.git#113.33.00+4.05'
     opam pin add -yn irmin.0.10.1 'https://github.com/talex5/irmin.git#cuekeeper'
-    opam pin add -yn irmin-indexeddb.0.5 'https://github.com/talex5/irmin-indexeddb.git#v0.5'
+    opam pin add -yn irmin-indexeddb.0.6 https://github.com/talex5/irmin-indexeddb.git#v0.6
+    opam pin add -yn git.1.7.1 https://github.com/talex5/ocaml-git.git#cuekeeper
 
 Install the dependencies (`-t` includes the test dependencies too):
 

--- a/lib/utils/git_storage.ml
+++ b/lib/utils/git_storage.ml
@@ -309,13 +309,12 @@ module Make (I : Irmin.S with type key = string list and type value = string
     let empty t = V.empty () >|= Staging.of_view t
   end
 
-  let make config task_maker =
+  let make r task_maker =
     begin match Bin_prot.Size.bin_size_int64 0x8000L with
     | 5 -> ()
     | x ->
         Ck_utils.bug
           "Bin_prot serialisation is broken (says it needs %d bytes to store 0x8000). \
           Ensure js_of_ocaml branch is pinned." x end;
-    I.Repo.create config >|= fun r ->
-    {r; task_maker}
+    Lwt.return {r; task_maker}
 end

--- a/lib/utils/git_storage.mli
+++ b/lib/utils/git_storage.mli
@@ -7,5 +7,5 @@ module Make (I : Irmin.S with type key = string list and type value = string and
             type commit_id = Irmin.Hash.SHA1.t and type branch_id = string) : sig
   include Git_storage_s.S
 
-  val make : Irmin.config -> (string -> Irmin.task) -> Repository.t Lwt.t
+  val make : I.Repo.t -> (string -> Irmin.task) -> Repository.t Lwt.t
 end

--- a/opam
+++ b/opam
@@ -28,7 +28,7 @@ depends: [
   "tar"
   "cohttp"
   "cohttp-lwt-jsoo"
-  "irmin-indexeddb" {>= "0.3"}
+  "irmin-indexeddb" {= "0.6"}
   "crunch" {build}
   "ppx_sexp_conv"
   "lwt"

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -1270,3 +1270,9 @@ pre code {
 a.ck-in-progress {
 	background: yellow;
 }
+
+pre.migration-log {
+	margin: 1em;
+	padding: 1em;
+	border: 1px solid black;
+}

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -429,7 +429,8 @@ let suite =
         let wait s =
           Test_clock.run_to (!Test_clock.time +. s) in
         run_to_day 0;
-        Git.make config task >>= M.make >>= fun m ->
+        Store.Repo.create config >>= fun repo ->
+        Git.make repo task >>= M.make >>= fun m ->
         M.set_mode m `Process;
         let process_tree = M.tree m |> expect_tree in
         let job = lookup ["Job"] process_tree |> expect_area in
@@ -888,7 +889,8 @@ let suite =
                 let branch_d name =
                   Store.Repo.create config >>= fun repo ->
                   Store.Repo.remove_branch repo name in
-                Git.make config task >>= fun repo ->
+                Store.Repo.create config >>= fun repo ->
+                Git.make repo task >>= fun repo ->
                 let commit ~parents msg =
                   branch_d msg >>= fun () ->
                   random_state ~common ~random repo >>= fun s ->
@@ -966,7 +968,8 @@ let suite =
 
         (* Start a new client ("laptop").
          * It will see that the server is empty, create a new default state and push it. *)
-        Laptop_client.Git.make config task >>= fun client_git ->
+        Laptop_store.Repo.create config >>= fun repo ->
+        Laptop_client.Git.make repo task >>= fun client_git ->
         Laptop_client.M.make ~server:(Uri.of_string "http://example.com/") client_git >>= fun laptop ->
 
         (* Check the server now has the new state. *)
@@ -1000,7 +1003,8 @@ let suite =
 
         (* Create a new client ("mobile"). It should see the sync'd changes. *)
         Mobile_client.(
-          Git.make config task >>= fun mobile_git ->
+          Mobile_store.Repo.create config >>= fun repo ->
+          Git.make repo task >>= fun mobile_git ->
           M.make ~server:(Uri.of_string "http://example.com/") mobile_git >>= fun mobile ->
           let next_actions = M.tree mobile |> expect_tree in
           next_actions |> assert_tree ~label:"fresh mobile client" [


### PR DESCRIPTION
This will show a migration box on first use showing the progress updating to the new format. After this, the database is in Git format and should therefore work with newer versions of Irmin.

On my machine, converting my CueKeeper history from 2015-03-09 to now (15,193 commits) took about 20 minutes in Firefox.