### PR TITLE
Upgrade to Irmin 1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN sudo apt-get -y update && sudo apt-get -y install aspcud zip m4 autoconf build-essential gcc-multilib ca-certificates git rsync time --no-install-recommends
 RUN opam init --comp=4.05.0+32bit --disable-sandboxing
 RUN opam pin add -yn reactiveData https://github.com/hhugo/reactiveData.git
-RUN opam pin add -yn irmin-git.1.0.0 https://github.com/talex5/irmin.git#1.0.0-cuekeeper
-RUN opam pin add -yn irmin-indexeddb.1.0 https://github.com/talex5/irmin-indexeddb.git#v1.0
-RUN opam pin add -yn git.1.10.0 https://github.com/talex5/ocaml-git.git#1.10.0-cuekeeper
+RUN opam pin add -yn irmin-git.1.4.0 https://github.com/talex5/irmin.git#1.4.0-cuekeeper
+RUN opam pin add -yn irmin-indexeddb.1.3 https://github.com/talex5/irmin-indexeddb.git#irmin-1.3
 RUN mkdir /home/opam/cuekeeper
 COPY --chown=opam cuekeeper.opam /home/opam/cuekeeper/
 WORKDIR /home/opam/cuekeeper

--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ Ensure you're using OCaml 4.05.0 (check with `ocaml -version`). If not, switch t
 Pin a few patches we require:
 
     opam pin add -yn reactiveData https://github.com/hhugo/reactiveData.git
-    opam pin add -yn irmin-git.1.0.0 https://github.com/talex5/irmin.git#1.0.0-cuekeeper
-    opam pin add -yn irmin-indexeddb.1.0 https://github.com/talex5/irmin-indexeddb.git#v1.0
-    opam pin add -yn git.1.10.0 https://github.com/talex5/ocaml-git.git#1.10.0-cuekeeper
+    opam pin add -yn irmin-git.1.4.0 https://github.com/talex5/irmin.git#1.4.0-cuekeeper
+    opam pin add -yn irmin-indexeddb.1.3 https://github.com/talex5/irmin-indexeddb.git#irmin-1.3
 
 Install the dependencies (`-t` includes the test dependencies too):
 

--- a/cuekeeper.opam
+++ b/cuekeeper.opam
@@ -18,11 +18,12 @@ depends: [
   "omd"
   "fmt"
   "logs"
+  "irmin-mem" {with-test}
   "ounit" {with-test}
   "tar"
   "cohttp"
   "cohttp-lwt-jsoo"
-  "irmin-indexeddb" {>= "1.0"}
+  "irmin-indexeddb" {>= "1.3"}
   "crunch" {build}
   "ppx_sexp_conv"
   "lwt"

--- a/js/dune
+++ b/js/dune
@@ -3,6 +3,4 @@
  (modes byte js)
  (preprocess (pps js_of_ocaml-ppx))
  (libraries cuekeeper js_of_ocaml js_of_ocaml-tyxml js_of_ocaml-lwt
-            cohttp-lwt-jsoo irmin-indexeddb omd)
- (js_of_ocaml
-  (flags +cstruct/cstruct.js)))
+            cohttp-lwt-jsoo irmin-indexeddb omd))

--- a/lib/utils/git_storage.ml
+++ b/lib/utils/git_storage.ml
@@ -146,7 +146,7 @@ module Make (I : Irmin.S
           files := (header, write) :: !files;
           Lwt.return_unit
         | step, `Node ->
-          I.Tree.find_tree tree [step] >>= scan ~path:(path @ [step])
+          I.Tree.get_tree tree [step] >>= scan ~path:(path @ [step])
       in
       (* Cannot use [I.Tree.to_concrete] here due to https://github.com/mirage/irmin/pull/525 *)
       I.Commit.tree t.commit >>= fun root ->

--- a/server/config.ml
+++ b/server/config.ml
@@ -11,8 +11,9 @@ let main =
 let conf = crunch "conf"
 
 let packages = [
-  package "irmin" ~min:"1.0.0" ~max:"1.1.0";
-  package "irmin-git" ~min:"1.0.0" ~max:"1.1.0";
+  package "irmin" ~min:"1.3.0" ~max:"2.0.0";
+  package "irmin-git" ~min:"1.3.0" ~max:"2.0.0";
+  package "irmin-mem" ~min:"1.3.0" ~max:"2.0.0";
   package "tls";
   package "cohttp-mirage";
 ]

--- a/tests/dune
+++ b/tests/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries cuekeeper lwt.unix oUnit irmin fmt.tty logs.fmt))
+ (libraries cuekeeper lwt.unix oUnit irmin fmt.tty logs.fmt irmin-mem))
 
 (alias
  (name   runtest)


### PR DESCRIPTION
Also works with 1.4. This will allow upgrading from OCaml 4.5. Also, it uses a newer version of ocaml-git, which doesn't require a pin.