### PR TITLE
Fix the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ server/conf/server.pem: server/conf/server.key
 
 server: server/conf/server.pem
 	rm -rf _build/static
-	mkdir _build/static
+	mkdir -p _build/static
 	cp -r resources _build/static/
 	dune build --profile=release ./js/client.bc.js
 	cp _build/default/js/client.bc.js _build/static/resources/js/cuekeeper.js

--- a/server/config.ml
+++ b/server/config.ml
@@ -14,7 +14,7 @@ let packages = [
   package "irmin" ~min:"1.3.0" ~max:"2.0.0";
   package "irmin-git" ~min:"1.3.0" ~max:"2.0.0";
   package "irmin-mem" ~min:"1.3.0" ~max:"2.0.0";
-  package "tls";
+  package "tls" ~max:"0.11.0";
   package "cohttp-mirage";
 ]
 


### PR DESCRIPTION
- `mkdir` requires `-p` on macos.
- The latest tls uses mirage-crypto and therefore some different RNG initialisation.

Should fix #27.