### PR TITLE
Update to reactiveData.0.2 API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM ocurrent/opam:debian-10-ocaml-4.07@sha256:2f9a9fc195b29f1006d0f97ae4c6300fb175800703b12a15b51583a1f7a547b7
 #FROM ocurrent/opam:debian-10-ocaml-4.07
-RUN opam pin add -yn reactiveData https://github.com/hhugo/reactiveData.git
-RUN opam pin add -yn irmin-git.1.4.0 https://github.com/talex5/irmin.git#1.4.0-cuekeeper
-RUN opam pin add -yn irmin-indexeddb.1.3 https://github.com/talex5/irmin-indexeddb.git#irmin-1.3
 RUN mkdir /home/opam/cuekeeper
 COPY --chown=opam cuekeeper.opam /home/opam/cuekeeper/
 WORKDIR /home/opam/cuekeeper

--- a/cuekeeper.opam
+++ b/cuekeeper.opam
@@ -32,8 +32,8 @@ depends: [
   "dune" {>= "1.11.0"}
 ]
 pin-depends: [
-  ["irmin-git.1.4.0" "git+https://github.com/talex5/irmin.git#1.4.0-cuekeeper"]
-  ["irmin-indexeddb.1.3" "git+https://github.com/talex5/irmin-indexeddb.git#irmin-1.3"]
+  ["irmin-git.1.4.0" "git+https://github.com/talex5/irmin.git#dedb0dd44b70806b1ab68c666c140c27caebe1c2"]
+  ["irmin-indexeddb.1.3" "git+https://github.com/talex5/irmin-indexeddb.git#c13c3e489af66868ddd86be37c958e56375db43b"]
 ]
 build: [
   [make "client"]

--- a/cuekeeper.opam
+++ b/cuekeeper.opam
@@ -12,7 +12,7 @@ depends: [
   "uuidm"
   "irmin"
   "tyxml" {>= "4.3.0"}
-  "reactiveData"
+  "reactiveData" {>= "0.2"}
   "js_of_ocaml" {>= "3.0.0"}
   "js_of_ocaml-tyxml"
   "omd"
@@ -32,7 +32,6 @@ depends: [
   "dune" {>= "1.11.0"}
 ]
 pin-depends: [
-  ["reactiveData.dev" "git+https://github.com/hhugo/reactiveData.git"]
   ["irmin-git.1.4.0" "git+https://github.com/talex5/irmin.git#1.4.0-cuekeeper"]
   ["irmin-indexeddb.1.3" "git+https://github.com/talex5/irmin-indexeddb.git#irmin-1.3"]
 ]

--- a/js/ck_template.ml
+++ b/js/ck_template.ml
@@ -61,7 +61,7 @@ let omd_date_ext =
   end
 
 let show_modal, modal_div =
-  let dropdown, set_dropdown = ReactiveData.RList.make [] in
+  let dropdown, set_dropdown = ReactiveData.RList.create [] in
   let dropdown_style, set_dropdown_style = React.S.create "" in
   let modal_div =
     R.Html5.div ~a:[a_class ["f-dropdown"; "ck-modal"]; R.Html5.a_style dropdown_style] dropdown in
@@ -478,11 +478,11 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
     item
 
   let make_sync m =
-    let log_elem, log_elem_h = ReactiveData.RList.make [] in
+    let log_elem, log_elem_h = ReactiveData.RList.create [] in
     let log_t = M.enable_log m in
     async ~name:"make_sync" (fun () ->
       log_t >|= fun items ->
-      log_elem_h |> ReactiveData.RList.append (
+      log_elem_h |> ReactiveData.RList.snoc (
         R.Html5.ol ~a:[a_class ["ck-history"]] (ReactiveData.RList.map (make_log_entry m) items)
       )
     );
@@ -1238,7 +1238,7 @@ module Make (M : Ck_model_s.MODEL with type gui_data = Gui_tree_data.t) = struct
   let history_uuid = Ck_id.of_string "aeeb4ba1-ae68-43ff-b23e-1f66e8b950a3"
 
   let make_details_area m =
-    let details_pane, details_handle = ReactiveData.RList.make [] in
+    let details_pane, details_handle = ReactiveData.RList.create [] in
     let remove uuid =
       let current_items = ReactiveData.RList.value details_pane in
       match index_of uuid current_items with

--- a/lib/ck_utils.ml
+++ b/lib/ck_utils.ml
@@ -67,7 +67,7 @@ let rlist_of ?init s =
     | None -> React.S.value s
     | Some v -> v in
   let changes = React.S.changes s |> React.E.map (fun x -> ReactiveData.RList.Set x) in
-  ReactiveData.RList.make_from init changes
+  ReactiveData.RList.from_event init changes
 
 (* Get the index of an item in an assoc list. *)
 let index_of key items =

--- a/lib/utils/delta_RList.ml
+++ b/lib/utils/delta_RList.ml
@@ -38,5 +38,5 @@ module Make (Key : Set.OrderedType)
           current := new_list;
           patch
       ) in
-    ReactiveData.RList.make_from (List.map snd !current) e
+    ReactiveData.RList.from_event (List.map snd !current) e
 end


### PR DESCRIPTION
Removes one pin-depends. Also, give exact hashes for the other two (ocaml-ci requires this).