### PR TITLE
Don't schedule display updates in time-travel mode

### DIFF
--- a/lib/ck_update.ml
+++ b/lib/ck_update.ml
@@ -32,6 +32,7 @@ module Make(Git : Git_storage_s.S) (Clock : Ck_clock.S) (R : Ck_rev.S with type 
     Lwt.cancel (t.alarm);
     match R.expires t.head with
     | None -> ()
+    | Some _ when t.fixed_head <> None -> () (* Pointless in time-travel mode *)
     | Some date ->
         let time = Ck_time.unix_time_of date in
         let delay = min max_sleep_time (time -. Clock.now ()) in


### PR DESCRIPTION
If a waiting item is scheduled then we arrange to be woken up when it's due so that the display can be updated. However, this should be disabled when in time-machine mode as otherwise it will keep firing, wasting CPU time.