### PR TITLE
make server: remove a buggy dir existance check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ docker-build:
 
 server/conf/server.key:
 	@echo Generating server key...
-	[ -d server/conf] || mkdir -p server/conf
+	mkdir -p server/conf
 	openssl genpkey -out $@ -outform PEM -algorithm RSA -pkeyopt rsa_keygen_bits:4096
 
 server/conf/server.pem: server/conf/server.key


### PR DESCRIPTION
It is not needed, since mkdir -p already ensures that the directory will be made.

Also, the check was buggy anyway and produced a warning:

```
[ -d server/conf] || mkdir -p server/conf
sh: line 1: [: missing `]'
```

It was checking for a directory server/conf], which is not server/conf.